### PR TITLE
Chapter 0: replace call to `print` with call to `warn`

### DIFF
--- a/chapter-0.md
+++ b/chapter-0.md
@@ -41,7 +41,7 @@ Create a file called `main.zig`, with the following contents:
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("Hello, {}!\n", .{"World"});
+    std.debug.warn("Hello, {}!\n", .{"World"});
 }
 ```
 ###### (note: make sure your file is using spaces for indentation, LF line endings and UTF-8 encoding!)


### PR DESCRIPTION
std.debug.print does not exist:

    ./foo.zig:4:14: error: container 'std.debug' has no member called 'print'
        std.debug.print("Hello, world!\n", .{});