### PR TITLE
Change f32 hashmap keys to u32

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -422,15 +422,15 @@ Let's put some values in a hash map. It is worth noting that the order of insert
 test "hashing" {
     const Point = struct { x: i32, y: i32 };
 
-    var map = std.AutoHashMap(f32, Point).init(
+    var map = std.AutoHashMap(u32, Point).init(
         test_allocator,
     );
     defer map.deinit();
 
-    try map.put(1.525, .{ .x = 1, .y = -4 });
-    try map.put(1.550, .{ .x = 2, .y = -3 });
-    try map.put(1.575, .{ .x = 3, .y = -2 });
-    try map.put(1.600, .{ .x = 4, .y = -1 });
+    try map.put(1525, .{ .x = 1, .y = -4 });
+    try map.put(1550, .{ .x = 2, .y = -3 });
+    try map.put(1575, .{ .x = 3, .y = -2 });
+    try map.put(1600, .{ .x = 4, .y = -1 });
 
     expect(map.count() == 4);
 


### PR DESCRIPTION
Hashing floats is generally bad practice (values that compare equal can have multiple representations), and I removed support for it in `AutoHashMap` in https://github.com/ziglang/zig/commit/345cb3200c353d6fb7aeb0e058986d8ca59ced1e .