### PR TITLE
Fix Hello World Example

### DIFF
--- a/chapter-0.md
+++ b/chapter-0.md
@@ -69,7 +69,7 @@ Create a file called `main.zig`, with the following contents:
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("Hello, {}!\n", .{"World"});
+    std.debug.warn("Hello, {}!\n", .{"World"});
 }
 ```
 ###### (note: make sure your file is using spaces for indentation, LF line endings and UTF-8 encoding!)


### PR DESCRIPTION
After seeing a comment on Hacker News regarding that this example was broken, I figured it would be good to update it.

Currently, `zig build-exe main.zig` has a build error:

```sh
zig build-exe main.zig
Semantic Analysis [632/820] ./main.zig:4:14: error: container 'std.debug' has no member called 'print'
    std.debug.print("Hello, {}!\n", .{"World"});
             ^
```

This small patch fixes it by changing `print` to be `warn` instead.