### PR TITLE
Change macosx to macos

### DIFF
--- a/chapter-3.md
+++ b/chapter-3.md
@@ -59,7 +59,7 @@ Some CPU architectures that you can cross-compile for:
 
 Some operating systems you can cross-compile for:
 - `linux`
-- `macosx`
+- `macos`
 - `windows`
 - `freebsd`
 - `netbsd`


### PR DESCRIPTION
For the sake of consistency with the new command in master, change `macosx` to `macos` as the name of the target platform