### PR TITLE
Update chapter-0.md

### DIFF
--- a/chapter-0.md
+++ b/chapter-0.md
@@ -29,7 +29,7 @@ https://ziglang.org/download/
 2. Add zig to your path
    - linux, macos, bsd
 
-      Add the location of your zig binary to your `PATH` environment variable. For an installation, add `export PATH=$PATH:~/zig/zig` or similar to your `/etc/profile` (system-wide) or `$HOME/.profile`. If these changes do not apply immediately, run the line from your shell.
+      Add the location of your zig binary to your `PATH` environment variable. For an installation, add `export PATH=$PATH:~/zig` or similar to your `/etc/profile` (system-wide) or `$HOME/.profile`. If these changes do not apply immediately, run the line from your shell.
    - windows
 
       a) System wide (admin powershell)


### PR DESCRIPTION
export $PATH=$PATH:~/zig/zig does not actually give linux a location to run the binary, and ignores it. quick fix is just to replace it with ``export $PATH=$PATH:~/zig``