### PR TITLE
Add actual formatting specifier, instead of {}

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -674,7 +674,7 @@ test "terminated fmt" {
 
     expect(eql(
         u8,
-        try bufPrint(&b, "{}", .{hello}),
+        try bufPrint(&b, "{s}", .{hello}),
         "hello!",
     ));
 }


### PR DESCRIPTION
The example should use the specifier as do the other examples. (That it can also be inferred and then has the same result is a different matter.)