### PR TITLE
Replace `std.debug.print` with `std.debug.warn`

### DIFF
--- a/chapter-0.md
+++ b/chapter-0.md
@@ -69,7 +69,7 @@ Create a file called `main.zig`, with the following contents:
 const std = @import("std");
 
 pub fn main() void {
-    std.debug.print("Hello, {s}!\n", .{"World"});
+    std.debug.warn("Hello, {s}!\n", .{"World"});
 }
 ```
 ###### (note: make sure your file is using spaces for indentation, LF line endings and UTF-8 encoding!)


### PR DESCRIPTION
Hello, I'm new to Zig.
When I read the chapter 0 of ziglearn, I noticed that the Hello World example doesn't work. It seems `std.debug.print` should be `std.debug.warn`.