### PR TITLE
chapter-4: clarify callconv

### DIFF
--- a/chapter-4.md
+++ b/chapter-4.md
@@ -46,12 +46,12 @@ Calling conventions describe how functions are called. This includes how argumen
 
 In Zig, the attribute `callconv` may be given to a function. The calling conventions available may be found in [std.builtin.CallingConvention](https://ziglang.org/documentation/master/std/#std;builtin.CallingConvention). Here we make use of the cdecl calling convention.
 ```zig
-fn add(a: u32, b: u32) callconv (.C) u32 {
+fn add(a: u32, b: u32) callconv(.C) u32 {
     return a + b;
 }
 ```
 
-Using a calling convention is crucial when you're calling C code from Zig, or vice versa.
+Marking your functions with the C calling convention is crucial when you're calling Zig from C.
 
 # Extern Structs
 


### PR DESCRIPTION
A user thought they needed to mark their Zig wrapper function as `callconv(.C)` because they were calling into C from Zig. This meant they couldn't use error unions and it got confusing.