### PR TITLE
Chapter 1: Clarify some language around payload captures

### DIFF
--- a/chapter-1.md
+++ b/chapter-1.md
@@ -721,7 +721,7 @@ test "simple union"...access of inactive union field
            ^
 ```
 
-Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, this time to switch on the tag type of a union while also capturing the value it contains. Captured values are immutable, so pointers must be taken to mutate the values.
+Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, to switch on the tag type of a union while also capturing the value it contains. Here we use a _pointer capture_; captured values are immutable, but with the `|*value|` syntax we can capture a pointer to the values instead of the values themselves. This allows us to use dereferencing to mutate the original value.
 
 ```zig
 const Tag = enum { a, b, c };
@@ -954,7 +954,7 @@ test "orelse unreachable" {
 
 Payload capturing works in many places for optionals, meaning that in the event that it is non-null we can "capture" its non-null value.
 
-Here we use an `if` optional payload capture; a and b are equivalent here. `if (b) |value|` captures the value of `b` (in the cases where `b` is not null), and copies it inside `value`.
+Here we use an `if` optional payload capture; a and b are equivalent here. `if (b) |value|` captures the value of `b` (in the cases where `b` is not null), and and makes it available as `value`. As in the union example, the captured value is immutable, but we can still use a pointer capture to modify the value stored in `b`.
 
 ```zig
 test "if optional payload capture" {
@@ -963,8 +963,11 @@ test "if optional payload capture" {
         const value = a.?;
     }
 
-    const b: ?i32 = 5;
-    if (b) |value| {}
+    var b: ?i32 = 5;
+    if (b) |*value| {
+        value.* += 1;
+    }
+    try expect(b.? == 6);
 }
 ```
 

--- a/chapter-1.md
+++ b/chapter-1.md
@@ -260,7 +260,7 @@ test "error union" {
 }
 ```
 
-Functions often return error unions. Here's one using a catch with __payload capturing__ to take the value of the error. Side note: some languages use similar syntax for lambdas - this is not the case for Zig.
+Functions often return error unions. Here's one using a catch, where the `|err|` syntax receives the value of the error. This is called __payload capturing__, and is used similarly in many places. We'll talk about it in more detail later in the chapter. Side note: some languages use similar syntax for lambdas - this is not the case for Zig.
 
 ```zig
 fn failingFunction() error{Oops}!void {
@@ -703,25 +703,25 @@ Bare union types do not have a guaranteed memory layout. Because of this, bare u
 
 <!--fail_test-->
 ```zig
-const Payload = union {
+const Result = union {
     int: i64,
     float: f64,
     bool: bool,
 };
 
 test "simple union" {
-    var payload = Payload{ .int = 1234 };
-    payload.float = 12.34;
+    var result = Result{ .int = 1234 };
+    result.float = 12.34;
 }
 ```
 ```
 test "simple union"...access of inactive union field
 .\tests.zig:342:12: 0x7ff62c89244a in test "simple union" (test.obj)
-    payload.float = 12.34;
+    result.float = 12.34;
            ^
 ```
 
-Tagged unions are unions which use an enum used to detect which field is active. Here we make use of a switch with payload capturing; captured values are immutable so pointers must be taken to mutate the values.
+Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, this time to switch on the tag type of a union while also capturing the value it contains. Captured values are immutable, so pointers must be taken to mutate the values.
 
 ```zig
 const Tag = enum { a, b, c };
@@ -1160,7 +1160,7 @@ test "**" {
 
 # Payload Captures
 
-Payload captures use the syntax `|value|` and appear in many places. These are used to "capture" the value from something.
+Payload captures use the syntax `|value|` and appear in many places, some of which we've seen already. Wherever they appear, they are used to "capture" the value from something.
 
 With if statements and optionals.
 ```zig
@@ -1262,7 +1262,7 @@ test "switch capture" {
 }
 ```
 
-So far, we have only shown payload captures with copy semantics (i.e. the captured value is a copy of the original value). We can also modify captured values by taking them as pointers, using the `|*value|` syntax. This is called a *pointer capture*.
+As we saw in the Unions section, by default captured values are immutable (similar to function arguments) and must be copied in order to modify them. With payload captures, we also have the option to capture the values as pointers using the `|*value|` syntax. This is called a *pointer capture*, and allows us to modify captured values directly:
 
 ```zig
 test "for with pointer capture" {

--- a/chapter-1.md
+++ b/chapter-1.md
@@ -1262,7 +1262,7 @@ test "switch capture" {
 }
 ```
 
-As we saw in the Unions section, by default captured values are immutable (similar to function arguments) and must be copied in order to modify them. With payload captures, we also have the option to capture the values as pointers using the `|*value|` syntax. This is called a *pointer capture*, and allows us to modify captured values directly:
+As we saw in the Unions section, values captured with the `|val|` syntax are immutable (similar to function arguments) and only copies of them are modifiable. With payload captures, we can instead capture the values as pointers using the `|*value|` syntax. This is called a *pointer capture*, and allows us to modify the original value by dereferencing the pointer:
 
 ```zig
 test "for with pointer capture" {

--- a/chapter-1.md
+++ b/chapter-1.md
@@ -697,7 +697,7 @@ test "automatic dereference" {
 
 # Unions
 
-Zig's union's allow you to define types which store one value of many possible typed fields; only one field may be active at one time.
+Zig's unions allow you to define types which store one value of many possible typed fields; only one field may be active at one time.
 
 Bare union types do not have a guaranteed memory layout. Because of this, bare unions cannot be used to reinterpret memory. Accessing a field in a union which is not active is detectable illegal behaviour.
 

--- a/chapter-1.md
+++ b/chapter-1.md
@@ -721,7 +721,7 @@ test "simple union"...access of inactive union field
            ^
 ```
 
-Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, to switch on the tag type of a union while also capturing the value it contains. Here we use a _pointer capture_; captured values are immutable, but with the `|*value|` syntax we can capture a pointer to the values instead of the values themselves. This allows us to use dereferencing to mutate the original value.
+Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, to switch on the tag type of a union while also capturing the value it contains. Here we use a *pointer capture*; captured values are immutable, but with the `|*value|` syntax we can capture a pointer to the values instead of the values themselves. This allows us to use dereferencing to mutate the original value.
 
 ```zig
 const Tag = enum { a, b, c };
@@ -1265,7 +1265,7 @@ test "switch capture" {
 }
 ```
 
-As we saw in the Unions section, values captured with the `|val|` syntax are immutable (similar to function arguments) and only copies of them are modifiable. With payload captures, we can instead capture the values as pointers using the `|*value|` syntax. This is called a *pointer capture*, and allows us to modify the original value by dereferencing the pointer:
+As we saw in the Union and Optional sections above, values captured with the `|val|` syntax are immutable (similar to function arguments), but we can use pointer capture to modify the original values. This captures the values as pointers that are themselves still immutable, but because the value is now a pointer, we can modify the original value by dereferencing it:
 
 ```zig
 test "for with pointer capture" {


### PR DESCRIPTION
Hey I'm finally getting around to checking out Zig, and am reading through the docs and found some things confusing, so here's my attempt to make them better! My context is that I'm fairly experienced in a wide variety of languages, perhaps most relevantly C++ and a bit of Rust, so that's my reference point here.

Firstly, payload captures were mentioned a couple times before actually being explained, without actually explaining what they were. The first time they're mentioned, I added a brief explanation of what bit of code _is_ the payload capture and mentioned we'll go more in depth later, The second time they came up, I elaborated a bit more on what we're doing with them there.

It might make more sense to move the whole "Payload Capture" section up and talk about them earlier, before we use them three times, but that's a bigger change and I think it's fine as-is, I realize it's impossible to explain everything in detail before it's used.

A more significant editorial decision was removing the reference to captured values using "copy semantics", which is technically true given how I would translate my understanding of the term from C++ into Zig, but I think it is a confusing way to explain how captures work. Additionally, the attempted clarification ("the captured value is a copy of the original value") is _not_ true - if it were, this code would work:
```
const Whatever = union(enum) { a: u32, b: u16, c: u8 };
var b = Whatever{ .b = 5 };
switch (b) {
    .b => |val| {
        val += 1;
    },
    else => {},
}
```
Instead, as expected given what I learned up in the Unions section, I get "error: cannot assign to constant", because the captured value is immutable, and no copy has been made.

So I just avoided "copy semantics" language altogether and modeled this explanation after the Unions section, referring to the values being immutable by default and requiring a copy to modify.

I'm open to other thoughts here, but I think "copy semantics" is a technical term that has subtly different shades of meaning depending on the language, and doesn't do much to explain what's happening here to someone new to Zig, even if they are familiar with the concept of copy vs move (vs copy-on-write vs reference...) semantics.

One last related tweak: the example variable in the Union section right before talking about payload captures was named `payload`, despite not using payload captures, so I renamed the example variable there to avoid confusion. I don't love "result" (for one, there's a namespace collision there with Rust), but I couldn't come up with anything better, and I think it's still an improvement over "payload" in this context.