### PR TITLE
Use "we" consistently

### DIFF
--- a/chapter-1.md
+++ b/chapter-1.md
@@ -57,7 +57,7 @@ const length = array.len; // 5
 
 Zig's basic if statement is simple in that it only accepts a `bool` value (of values `true` or `false`). There is no concept of truthy or falsy values.
 
-Here I will introduce testing. Save the below code and compile + run it with `zig test file-name.zig`. We will be using the [`expect`](https://ziglang.org/documentation/master/std/#std;testing.expect) function from the standard library, which will cause the test to fail if its given the value `false`. When a test fails, the error and stack trace will be shown.
+Here we will introduce testing. Save the below code and compile + run it with `zig test file-name.zig`. We will be using the [`expect`](https://ziglang.org/documentation/master/std/#std;testing.expect) function from the standard library, which will cause the test to fail if its given the value `false`. When a test fails, the error and stack trace will be shown.
 
 ```zig
 const expect = @import("std").testing.expect;
@@ -1484,7 +1484,7 @@ test "vector indexing" {
 }
 ```
 
-The built-in function [`@splat`](https://ziglang.org/documentation/master/#splat) may be used to construct a vector where all of the values are the same. Here I am using it to multiply a vector by a scalar.
+The built-in function [`@splat`](https://ziglang.org/documentation/master/#splat) may be used to construct a vector where all of the values are the same. Here we use it to multiply a vector by a scalar.
 
 ```zig
 test "vector * scalar" {

--- a/chapter-5.md
+++ b/chapter-5.md
@@ -24,7 +24,7 @@ The style of Zig's async may be described as suspendible stackless coroutines. Z
 
 In the previous section we talked of how async functions can give control back to the caller, and how the async function can later take control back. This functionality is provided by the keywords [`suspend`, and `resume`](https://ziglang.org/documentation/master/#Suspend-and-Resume). When a function suspends, control flow returns to wherever it was last resumed; when a function is called via an `async` invocation, this is an implicit resume.
 
-In these examples, I have commented the order of execution. There are a few things to take in here:
+The comments in these examples indicate the order of execution. There are a few things to take in here:
 *  The `async` keyword is used to invoke functions in an async context.
 *  `async func()` returns the function's frame.
 *  We must store this frame.


### PR DESCRIPTION
There were just a couple "I" statements in the whole docs, so switch them to "we" or passive voice to be consistent with the rest of the voice.