### PR TITLE
Chapter 1: Improve phrasing of additional explanations of palyload captures

### DIFF
--- a/chapter-1.md
+++ b/chapter-1.md
@@ -721,7 +721,7 @@ test "simple union"...access of inactive union field
            ^
 ```
 
-Tagged unions are unions which use an enum used to detect which field is active. Here we make use payload capturing again, to switch on the tag type of a union while also capturing the value it contains. Here we use a *pointer capture*; captured values are immutable, but with the `|*value|` syntax we can capture a pointer to the values instead of the values themselves. This allows us to use dereferencing to mutate the original value.
+Tagged unions are unions which use an enum to detect which field is active. Here we make use of payload capturing again, to switch on the tag type of a union while also capturing the value it contains. Here we use a *pointer capture*; captured values are immutable, but with the `|*value|` syntax we can capture a pointer to the values instead of the values themselves. This allows us to use dereferencing to mutate the original value.
 
 ```zig
 const Tag = enum { a, b, c };


### PR DESCRIPTION
#111 added some explanations of payload captures.
This PR improves upon than and
- adds a missing `of`
- removes an unnecessary `used` 