### PR TITLE
Update chapter-2 AutoHashMap

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -595,8 +595,8 @@ test "hashing" {
     var iterator = map.iterator();
 
     while (iterator.next()) |entry| {
-        sum.x += entry.value.x;
-        sum.y += entry.value.y;
+        sum.x += entry.value_ptr.x;
+        sum.y += entry.value_ptr.y;
     }
 
     try expect(sum.x == 10);


### PR DESCRIPTION
since std.AutoHashMap's Entry (at least as of 0.8, haven't checked before) is defined as

```zig
pub const Entry = struct {
            key_ptr: *K,
            value_ptr: *V,
        };
```

To update the sum (`sum.x += entry.value.x;`) we actually need `sum.x += entry.value_ptr.x;`