### PR TITLE
Change return type for function `cmp`

### DIFF
--- a/chapter-5.md
+++ b/chapter-5.md
@@ -306,8 +306,8 @@ fn asyncMain() void {
 // priority queue of tasks
 // lower .expires => higher priority => to be executed before
 var timer_queue: std.PriorityQueue(Delay) = undefined;
-fn cmp(a: Delay, b: Delay) bool {
-    return a.expires < b.expires;
+fn cmp(a: Delay, b: Delay) std.math.Order {
+    return std.math.order(a.expires, b.expires);
 }
 
 pub fn main() !void {


### PR DESCRIPTION
On version 0.8.1, the function `cmp` should return `std.math.Order` instead of `bool`