### PR TITLE
Revert "fixed outdated std usage"

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -570,7 +570,7 @@ fn ticker(step: u8) void {
 var tick: isize = 0;
 
 test "threading" {
-    var thread = try std.Thread.spawn(.{}, ticker, .{@as(u8, 1)});
+    var thread = try std.Thread.spawn(ticker, @as(u8, 1));
     _ = thread;
     try expect(tick == 0);
     std.time.sleep(3 * std.time.ns_per_s / 2);
@@ -717,7 +717,7 @@ It is a common idiom to have a struct type with a `next` function with an option
 ```zig
 test "split iterator" {
     const text = "robust, optimal, reusable, maintainable, ";
-    var iter = std.mem.split(u8, text, ", ");
+    var iter = std.mem.split(text, ", ");
     try expect(eql(u8, iter.next().?, "robust"));
     try expect(eql(u8, iter.next().?, "optimal"));
     try expect(eql(u8, iter.next().?, "reusable"));

--- a/test-out.zig
+++ b/test-out.zig
@@ -32,7 +32,7 @@ pub fn main() !void {
         defer allocator.free(text);
         _ = try in.readAll(text);
 
-        var iter = std.mem.split(u8, text, "```");
+        var iter = std.mem.split(text, "```");
         outer: while (iter.next()) |token| {
             if (!std.mem.startsWith(u8, token, "zig")) continue;
 


### PR DESCRIPTION
This reverts commit 56171b7cac47eb0002b34370b4675ac63ef4f9a3.

The reverted commit seems to be using latest dev zig from master
but the chapters suggest v0.8. So, when running tests as prescrived in
the readme, it should be using the same zig version.
