### PR TITLE
Update to 0.9.0

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -36,7 +36,7 @@ The [`std.heap.FixedBufferAllocator`](https://ziglang.org/documentation/master/s
 test "fixed buffer allocator" {
     var buffer: [1000]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&buffer);
-    var allocator = &fba.allocator;
+    var allocator = fba.allocator();
 
     const memory = try allocator.alloc(u8, 100);
     defer allocator.free(memory);
@@ -52,7 +52,7 @@ test "fixed buffer allocator" {
 test "arena allocator" {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
-    var allocator = &arena.allocator;
+    var allocator = arena.allocator();
 
     _ = try allocator.alloc(u8, 1);
     _ = try allocator.alloc(u8, 10);
@@ -79,8 +79,8 @@ test "GPA" {
         const leaked = gpa.deinit();
         if (leaked) expect(false) catch @panic("TEST FAIL"); //fail test; can't try in defer as defer is executed after we return
     }
-    const bytes = try gpa.allocator.alloc(u8, 100);
-    defer gpa.allocator.free(bytes);
+    const bytes = try gpa.allocator().alloc(u8, 100);
+    defer gpa.allocator().free(bytes);
 }
 ```
 


### PR DESCRIPTION
Allocator usage was changed on [0.9.0](https://ziglang.org/download/0.9.0/release-notes.html#Allocgate)