### PR TITLE
Chapter 2: Fix arg iteration example

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -753,10 +753,10 @@ test "iterator looping" {
 ```zig
 test "arg iteration" {
     var arg_characters: usize = 0;
-    var iter = std.process.args();
-    while (try iter.next(test_allocator)) |arg| {
+    var iter = try std.process.argsWithAllocator(test_allocator);
+    defer iter.deinit();
+    while (iter.next()) |arg| {
         arg_characters += arg.len;
-        test_allocator.free(arg);
     }
     try expect(arg_characters > 0);
 }


### PR DESCRIPTION
The current example doesn't work because `std.process.args()` doesn't need an allocator at all. `std.process.argsWithAllocator()` takes one upon initialization, so its possible error occurs upon initialization, not during iteration. I don't know enough Zig to come up with a different example of an iterator yielding `?!T`, but I can at least make this example work again :sweat_smile: