### PR TITLE
Fix typo in the Random Numbers section

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -509,7 +509,7 @@ test "json parse with strings" {
 
 # Random Numbers
 
-Here we create a new prng using a 64 bit random seed. a, b, c, and are given random values via this prng. The expressions giving c and d values are equivalent. `DefaultPrng` is `Xoroshiro128`; there are other prngs available in std.rand.
+Here we create a new prng using a 64 bit random seed. a, b, c, and d are given random values via this prng. The expressions giving c and d values are equivalent. `DefaultPrng` is `Xoroshiro128`; there are other prngs available in std.rand.
 
 ```zig
 test "random numbers" {


### PR DESCRIPTION
This diff fixes a tiny typo in the "Random Numbers" section.
The sentence "_Here we create a new prng using a 64 bit random seed. a, b, c, and are given random values via this prng._" is missing the name of the **d** variable after the "_and_".