### PR TITLE
Update output directory.

### DIFF
--- a/chapter-3.md
+++ b/chapter-3.md
@@ -129,7 +129,7 @@ pub fn main() anyerror!void {
 }
 ```
 
-Upon using the `zig build` command, the executable will appear in the install path. Here we have not specified an install path, so the executable will be saved in `./zig-cache/bin`.
+Upon using the `zig build` command, the executable will appear in the install path. Here we have not specified an install path, so the executable will be saved in `./zig-out/bin`.
 
 # Builder
 


### PR DESCRIPTION
Running `zig build` w/ version 0.9.1 puts the binary in `zig-out` not `zig-cache`, at least on my machine with default settings.