### PR TITLE
Update chapter-2.md (early PR)

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -165,7 +165,7 @@ test "make dir" {
     try std.fs.cwd().makeDir("test-tmp");
     const dir = try std.fs.cwd().openDir(
         "test-tmp",
-        .{ .iterate = true },
+        .{ },
     );
     defer {
         std.fs.cwd().deleteTree("test-tmp") catch unreachable;
@@ -175,8 +175,12 @@ test "make dir" {
     _ = try dir.createFile("y", .{});
     _ = try dir.createFile("z", .{});
 
+    const iterDir = try std.fs.cwd().openIterableDir(
+        "test-tmp",
+        .{ },
+    );
     var file_count: usize = 0;
-    var iter = dir.iterate();
+    var iter = iterDir.iterate();
     while (try iter.next()) |entry| {
         if (entry.kind == .File) file_count += 1;
     }

--- a/chapter-2.md
+++ b/chapter-2.md
@@ -738,9 +738,9 @@ Some iterators have a `!?T` return type, as opposed to ?T. `!?T` requires that w
 
 ```zig
 test "iterator looping" {
-    var iter = (try std.fs.cwd().openDir(
+    var iter = (try std.fs.cwd().openIterableDir(
         ".",
-        .{ .iterate = true },
+        .{},
     )).iterate();
 
     var file_count: usize = 0;


### PR DESCRIPTION
Early PR preparing future zig version (0.10.0 ?).
This change follows the following commit on zig master : https://github.com/ziglang/zig/commit/262f4c7b3a850594a75ec154db2ba8d5f9f517ab.
OpenDirOptions doesn't provide a .iterate field anymore, and two distinct structs have been created : Dir & IterableDir. Thus, we need two distinct variable to create files in the directory and to iterate in it.