### PR TITLE
Update chapter-2.md

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -734,9 +734,9 @@ Some iterators have a `!?T` return type, as opposed to ?T. `!?T` requires that w
 
 ```zig
 test "iterator looping" {
-    var iter = (try std.fs.cwd().openDir(
+    var iter = (try std.fs.cwd().openIterableDir(
         ".",
-        .{ .iterate = true },
+        .{ .no_follow = true },
     )).iterate();
 
     var file_count: usize = 0;


### PR DESCRIPTION
zig 0.11 changed std.fs.cwd()    {.iterate } is not structure member