### PR TITLE
Update chapter-2.md

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -165,7 +165,7 @@ test "make dir" {
     try std.fs.cwd().makeDir("test-tmp");
     const dir = try std.fs.cwd().openDir(
         "test-tmp",
-        .{ .iterate = true },
+        .{},
     );
     defer {
         std.fs.cwd().deleteTree("test-tmp") catch unreachable;
@@ -176,7 +176,9 @@ test "make dir" {
     _ = try dir.createFile("z", .{});
 
     var file_count: usize = 0;
-    var iter = dir.iterate();
+    const idir = std.fs.cwd().openIterableDir(
+    "test-temp", .{} );
+    var iter = idir.iterate();
     while (try iter.next()) |entry| {
         if (entry.kind == .File) file_count += 1;
     }


### PR DESCRIPTION
Zig 0.11 Dir has no field .iterable. Type ItetableDir should be used.