### PR TITLE
Fixed for loop example regarding indexes

### DIFF
--- a/chapter-1.md
+++ b/chapter-1.md
@@ -148,7 +148,7 @@ test "for" {
     //character literals are equivalent to integer literals
     const string = [_]u8{ 'a', 'b', 'c' };
 
-    for (string, 0..) |character, index| {
+    for (string) |character, index| {
         _ = character;
         _ = index;
     }
@@ -157,7 +157,7 @@ test "for" {
         _ = character;
     }
 
-    for (string, 0..) |_, index| {
+    for (string) |_, index| {
         _ = index;
     }
 


### PR DESCRIPTION
For-loop examples in chapter 1 using indexes do not seem to be syntactically correct.
It currently reads in the form ``for(slice, range)`` but specifying the range does not seem to work with zig 0.10.1.