### PR TITLE
Chapter 2: Fix 'make dir' test

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -164,11 +164,12 @@ We can make directories and iterate over their contents. Here we will use an ite
 ```zig
 test "make dir" {
     try std.fs.cwd().makeDir("test-tmp");
-    const iter_dir = try std.fs.cwd().openIterableDir(
+    var iter_dir = try std.fs.cwd().openIterableDir(
         "test-tmp",
         .{},
     );
     defer {
+        iter_dir.close();
         std.fs.cwd().deleteTree("test-tmp") catch unreachable;
     }
 


### PR DESCRIPTION
Without this I get

```
Test [1/1] test.make dir... thread 34048 panic: attempt to unwrap error: FileBusy
C:\Users\sigod\AppData\Local\zig\lib\std\os\windows.zig:922:31: 0x7ff722d6aeea in DeleteFile (test.exe.obj)
        .SHARING_VIOLATION => return error.FileBusy,
                              ^
```