### PR TITLE
Chapter 2: Use .file from Kind enum

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -152,7 +152,7 @@ test "file stat" {
     defer file.close();
     const stat = try file.stat();
     try expect(stat.size == 0);
-    try expect(stat.kind == .File);
+    try expect(stat.kind == .file);
     try expect(stat.ctime <= std.time.nanoTimestamp());
     try expect(stat.mtime <= std.time.nanoTimestamp());
     try expect(stat.atime <= std.time.nanoTimestamp());
@@ -179,7 +179,7 @@ test "make dir" {
     var file_count: usize = 0;
     var iter = iter_dir.iterate();
     while (try iter.next()) |entry| {
-        if (entry.kind == .File) file_count += 1;
+        if (entry.kind == .file) file_count += 1;
     }
 
     try expect(file_count == 3);


### PR DESCRIPTION
The Kind enum defines the file type as .file

```zig
try expect(stat.kind == .File);
```
returns
```zig
fs.zig:30:30: error: no field named 'File' in enum 'fs.file.File.Kind'
    try expect(stat.kind == .File);
                            ~^~~~
/home/dir/bin/zig-0.11.0/zig-linux-x86_64-0.11.0-dev.3384+00ff65357/lib/std/fs/file.zig:37:22: note: enum declared here
    pub const Kind = enum {
                     ^~~~
```
Version
```bash
zig version
0.11.0-dev.3384+00ff65357
```
