### PR TITLE
Add method to override dest dir for zig build

### DIFF
--- a/chapter-3.md
+++ b/chapter-3.md
@@ -137,7 +137,7 @@ pub fn main() anyerror!void {
 }
 ```
 
-Upon using the `zig build` command, the executable will appear in the install path. Here we have not specified an install path, so the executable will be saved in `./zig-out/bin`.
+Upon using the `zig build` command, the executable will appear in the install path. Here we have not specified an install path, so the executable will be saved in `./zig-out/bin`. A custom install path can be specified using the `override_dest_dir` field in the `Step.Compile` struct.
 
 # Builder
 


### PR DESCRIPTION
We mention that the destination can be overridden, so we should also have a line next to it which specifies how.